### PR TITLE
fix(api): correct handling of choice zone flag

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -248,7 +248,6 @@ def get_address_independent_schools_info():
         "universal_magnet_traditional_school",
         "universal_magnet_traditional_program",
         "the_academies_of_louisville",
-        "choice_zone",
         "districtwide_pathways" # This is now our flag for universal pathways
     ]
     


### PR DESCRIPTION
Resolves a regression where all schools with a 'choice_zone' flag were being incorrectly added as universal magnets to every address lookup.

The logic is corrected to no longer treat the 'choice_zone' database flag as an address-independent universal option. The correct mechanism for adding choice schools is already handled by the geographic lookup and the  file.