### PR TITLE
feat(tours): add and serve school open house data

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -51,8 +51,6 @@ except Exception as e:
     print(f"⚠️ Warning: Could not load {os.path.basename(CHOICE_ZONE_OPTIONS_PATH)}. This feature will be disabled. Error: {e}")
 
 
-
-# <<< START: ADDED CODE >>>
 # --- Load Zone-Specific Magnet Data ---
 ZONE_MAGNETS_PATH = os.path.join(DATA_DIR, 'zone_specific_magnets.json')
 zone_specific_magnets_data = {}
@@ -62,7 +60,16 @@ try:
     print(f"✅ Successfully loaded zone-specific magnet data.")
 except Exception as e:
     print(f"⚠️ Warning: Could not load {os.path.basename(ZONE_MAGNETS_PATH)}. This feature will be disabled. Error: {e}")
-# <<< END: ADDED CODE >>>
+
+# --- Load Open House Data ---
+OPEN_HOUSE_PATH = os.path.join(DATA_DIR, 'open_house_dates.json')
+open_house_data = {}
+try:
+    with open(OPEN_HOUSE_PATH, 'r') as f:
+        open_house_data = json.load(f)
+    print(f"✅ Successfully loaded open house data.")
+except Exception as e:
+    print(f"⚠️ Warning: Could not load {os.path.basename(OPEN_HOUSE_PATH)}. This feature will be disabled. Error: {e}")
 
 # Shapefile paths
 choice_path = os.path.join(DATA_DIR, "ChoiceZone", "ChoiceZone.shp")
@@ -328,7 +335,13 @@ def get_school_details_by_scas(school_codes_adjusted):
             for row in results:
                 school_dict = dict(row)
                 sca = school_dict.get('school_code_adjusted')
-                if sca in unique_scas: details_map[sca] = school_dict
+                if sca in unique_scas: 
+                    # Nest the entire open house object under a single key
+                    if sca in open_house_data:
+                        school_dict['open_house_data'] = open_house_data[sca]
+                    else:
+                        school_dict['open_house_data'] = None
+                    details_map[sca] = school_dict
         except sqlite3.Error as e: print(f"Error querying details for SCAs {unique_scas}: {e}")
         finally: conn.close()
     return details_map

--- a/data/open_house_dates.csv
+++ b/data/open_house_dates.csv
@@ -1,329 +1,329 @@
-School Code Adjusted,School Name,Phone,Start Time,End Time,Type,Notes,Level
-275175,Alex R. Kennedy Elementary,(502) 485-6950,,,School Tour,Tours are 11:00 AM-2:00 PM,Elementary
-275185,Atkinson Elementary,(502) 485-8203,,,School Tour,Tours are 9:40-11:00 AM,Elementary
-275127,Auburndale Elementary,(502) 485-8204,,,School Tour,Tours are 8:00-9:00 AM,Elementary
-275044,Audubon Traditional Elementary,,11/5/2025 10:30 AM,11/5/2025 11:30 AM,School Tour,,Elementary
-275044,Audubon Traditional Elementary,,11/11/2025 5:30 PM,11/11/2025 6:30 PM,School Tour,,Elementary
-275044,Audubon Traditional Elementary,,11/12/2025 10:30 AM,11/12/2025 11:30 AM,School Tour,,Elementary
-275044,Audubon Traditional Elementary,,11/19/2025 10:30 AM,11/19/2025 11:30 AM,School Tour,,Elementary
-275055,Bates Elementary,,10/16/2025 10:30 AM,10/16/2025 11:30 AM,School Tour,,Elementary
-275055,Bates Elementary,,10/16/2025 1:30 PM,10/16/2025 2:30 PM,School Tour,,Elementary
-275055,Bates Elementary,,10/23/2025 10:30 AM,10/23/2025 11:30 AM,School Tour,,Elementary
-275055,Bates Elementary,,10/23/2025 1:30 PM,10/23/2025 2:30 PM,School Tour,,Elementary
-275055,Bates Elementary,,10/30/2025 10:30 AM,10/30/2025 11:30 AM,School Tour,,Elementary
-275055,Bates Elementary,,10/30/2025 1:30 PM,10/30/2025 2:30 PM,School Tour,,Elementary
-275055,Bates Elementary,,11/6/2025 10:30 AM,11/6/2025 11:30 AM,School Tour,,Elementary
-275055,Bates Elementary,,11/6/2025 1:30 PM,11/6/2025 2:30 PM,School Tour,,Elementary
-275055,Bates Elementary,,11/13/2025 10:30 AM,11/13/2025 11:30 AM,School Tour,,Elementary
-275055,Bates Elementary,,11/13/2025 1:30 PM,11/13/2025 2:30 PM,School Tour,,Elementary
-275055,Bates Elementary,,11/20/2025 10:30 AM,11/20/2025 11:30 AM,School Tour,,Elementary
-275055,Bates Elementary,,11/20/2025 1:30 PM,11/20/2025 2:30 PM,School Tour,,Elementary
-275055,Bates Elementary,,12/4/2025 10:30 AM,12/4/2025 11:30 AM,School Tour,,Elementary
-275055,Bates Elementary,,12/4/2025 1:30 PM,12/4/2025 2:30 PM,School Tour,,Elementary
-275055,Bates Elementary,,12/11/2025 10:30 AM,12/11/2025 11:30 AM,School Tour,,Elementary
-275055,Bates Elementary,,12/11/2025 1:30 PM,12/11/2025 2:30 PM,School Tour,,Elementary
-275149,Blake Elementary,(502) 485-8210,,,School Tour,Tours are 7:30-9:30 AM,Elementary
-275225,Bloom Elementary,,11/3/2025 2:00 PM,,School Tour,,Elementary
-275091,Blue Lick Elementary,(502) 485-8212,,,School Tour,,Elementary
-275094,Bowen Elementary,(502) 485-8213,,,School Tour,Tours are 11:00 AM-2:00 PM,Elementary
-275260,Brandeis Elementary,,10/29/2025 10:00 AM,10/29/2025 11:00 AM,School Tour,,Elementary
-275260,Brandeis Elementary,,10/29/2025 12:00 PM,10/29/2025 1:00 PM,School Tour,,Elementary
-275260,Brandeis Elementary,,11/5/2025 10:00 AM,11/5/2025 11:00 AM,School Tour,,Elementary
-275260,Brandeis Elementary,,11/5/2025 12:00 PM,11/5/2025 1:00 PM,School Tour,,Elementary
-275260,Brandeis Elementary,,11/12/2025 10:00 AM,11/12/2025 11:00 AM,School Tour,,Elementary
-275260,Brandeis Elementary,,11/12/2025 12:00 PM,11/12/2025 1:00 PM,School Tour,,Elementary
-275260,Brandeis Elementary,,11/19/2025 10:00 AM,11/19/2025 11:00 AM,School Tour,,Elementary
-275260,Brandeis Elementary,,11/19/2025 12:00 PM,11/19/2025 1:00 PM,School Tour,,Elementary
-275260,Brandeis Elementary,,12/3/2025 10:00 AM,12/3/2025 11:00 AM,School Tour,,Elementary
-275260,Brandeis Elementary,,12/3/2025 12:00 PM,12/3/2025 1:00 PM,School Tour,,Elementary
-275260,Brandeis Elementary,,12/10/2025 10:00 AM,12/10/2025 11:00 AM,School Tour,,Elementary
-275260,Brandeis Elementary,,12/10/2025 12:00 PM,12/10/2025 1:00 PM,School Tour,,Elementary
-275260,Brandeis Elementary,,12/17/2025 10:00 AM,12/17/2025 11:00 AM,School Tour,,Elementary
-275260,Brandeis Elementary,,12/17/2025 12:00 PM,12/17/2025 1:00 PM,School Tour,,Elementary
-275038,Breckinridge-Franklin,(502) 485-8215,,,School Tour,Tours are 10:00 AM-3:00 PM and 4:45-5:15 PM,Elementary
-275243,Byck Elementary,(502) 485-8221,,,School Tour,Tours are 10:30 AM-2:00 PM,Elementary
-275004,Camp Taylor Elementary,(502)485-8222,,,School Tour,Tours are 8:00 AM - 1:00 PM,Elementary
-275005,Cane Run Elementary,(502) 485-8223,,,School Tour,,Elementary
-275680,Carter Traditional Elementary,(502) 485-8225,,,School Tour,,Elementary
-275102,Chancey Elementary,,10/8/2025 8:30 AM,,School Tour,,Elementary
-275102,Chancey Elementary,,10/15/2025 8:30 AM,,School Tour,,Elementary
-275102,Chancey Elementary,,10/22/2025 8:30 AM,,School Tour,,Elementary
-275102,Chancey Elementary,,10/29/2025 8:30 AM,,School Tour,,Elementary
-275046,Chenoweth Elementary,,10/29/2025 10:00 AM,10/29/2025 11:00 AM,School Tour,15 minutes,Elementary
-275046,Chenoweth Elementary,,11/5/2025 10:00 AM,11/5/2025 11:00 AM,School Tour,15 minutes,Elementary
-275046,Chenoweth Elementary,,11/12/2025 10:00 AM,11/12/2025 11:00 AM,School Tour,15 minutes,Elementary
-275323,Cochran Elementary,(502) 485-8230,,,School Tour,,Elementary
-275083,Cochrane Elementary,,11/4/2025 2:45 PM,,School Tour,,Elementary
-275660,Coleridge-Taylor,,10/15/2025 10:00 AM,,School Tour,,Elementary
-275660,Coleridge-Taylor,,10/22/2025 10:00 AM,,School Tour,,Elementary
-275660,Coleridge-Taylor,,10/29/2025 10:00 AM,,School Tour,,Elementary
-275660,Coleridge-Taylor,,11/5/2025 10:00 AM,,School Tour,,Elementary
-275660,Coleridge-Taylor,,11/12/2025 10:00 AM,,School Tour,,Elementary
-275660,Coleridge-Taylor,,11/19/2025 10:00 AM,,School Tour,,Elementary
-275660,Coleridge-Taylor,,11/26/2025 10:00 AM,,School Tour,,Elementary
-275660,Coleridge-Taylor,,12/3/2025 10:00 AM,,School Tour,,Elementary
-275660,Coleridge-Taylor,,12/10/2025 10:00 AM,,School Tour,,Elementary
-275660,Coleridge-Taylor,,12/17/2025 10:00 AM,,School Tour,,Elementary
-275060,Coral Ridge Elementary,(502) 485-8234,,,School Tour,,Elementary
-275092,Crums Lane Elementary,(502) 485-8236,,,School Tour,,Elementary
-275082,Dixie Elementary,(502) 485-8238,,,School Tour,,Elementary
-275156,Dunn Elementary,(502) 485-8240,,,School Tour,"Tours are  9/9,10/10,11/6,12/5 ",Elementary
-275131,Eisenhower Elementary,(502) 485-8244,,,School Tour,,Elementary
-275010,Fairdale Elementary,(502) 485-8247,,,School Tour,,Elementary
-275212,Farmer Elementary,,10/28/2025 10:15 AM,,School Tour,,Elementary
-275212,Farmer Elementary,,11/13/2025 10:15 AM,,School Tour,,Elementary
-275011,Fern Creek Elementary,(502) 485-8250,11/13/2025 10:15 AM,,School Tour,Or call to schedule,Elementary
-275250,Field Elementary,(502) 485-8252,,,School Tour,,Elementary
-275270,Foster Traditional Academy,(502) 485-8253,,,School Tour,,Elementary
-275290,Frayser Elementary,(502) 485-8255,,,School Tour,,Elementary
-275061,Goldsmith Elementary,(502) 485-8258,,,School Tour,,Elementary
-275013,Greathouse/Shryock Traditional Elementary,,10/29/2025 10:00 AM,10/29/2025 11:00 AM,School Tour,,Elementary
-275013,Greathouse/Shryock Traditional Elementary,,11/6/2025 1:00 PM,11/6/2025 2:00 PM,School Tour,,Elementary
-275013,Greathouse/Shryock Traditional Elementary,,11/10/2025 10:00 AM,11/10/2025 11:00 AM,School Tour,,Elementary
-275013,Greathouse/Shryock Traditional Elementary,,12/2/2025 5:00 PM,12/2/2025 6:00 PM,School Tour,,Elementary
-275014,Greenwood Elementary,(502) 485-8260,,,School Tour,,Elementary
-275115,Gutermuth Elementary,(502) 485-8261,,,School Tour,,Elementary
-275121,Hartstern Elementary,(502) 485-8262,,,School Tour,,Elementary
-275048,Hawthorne Elementary,,11/6/2025 5:00 PM,11/6/2025 6:00 PM,School Tour,,Elementary
-275048,Hawthorne Elementary,,11/11/2025 9:30 AM,11/11/2025 10:30 AM,School Tour,,Elementary
-275048,Hawthorne Elementary,,12/4/2025 9:30 AM,12/4/2025 10:30 AM,School Tour,,Elementary
-275048,Hawthorne Elementary,,12/9/2025 5:00 PM,12/9/2025 6:00 PM,School Tour,,Elementary
-275300,Hazelwood Elementary,(502) 485-8264,,,School Tour,,Elementary
-275095,Hite Elementary,,11/3/2025 11:30 AM,11/3/2025 1:00 PM,School Tour,,Elementary
-275076,Indian Trail Elementary,(502) 485-8268,,,School Tour,,Elementary
-2751651,J. Graham Brown School,,11/7/2025 8:30 AM,,School Tour,,Elementary
-2751651,J. Graham Brown School,,11/11/2025 8:30 AM,,School Tour,,Elementary
-2751651,J. Graham Brown School,,11/18/2025 8:30 AM,,School Tour,,Elementary
-2751651,J. Graham Brown School,,12/5/2025 8:30 AM,,School Tour,,Elementary
-2751651,J. Graham Brown School,,12/17/2025 8:30 AM,,School Tour,,Elementary
-275325,Jacob Elementary,(502) 485-8271,,,School Tour,,Elementary
-275166,Jeffersontown Elementary,(502) 485-8274,,,School Tour,,Elementary
-275106,Johnsontown Road Elementary,(502) 485-8278,,,School Tour,,Elementary
-275720,Kennedy Elementary,(502) 485-8280,,,School Tour,,Elementary
-275059,Kenwood Elementary,(502) 485-8283,,,School Tour,,Elementary
-275079,Kerrick Elementary,(502) 485-8284,,,School Tour,,Elementary
-275432,King Elementary,,11/6/2025 5:00 PM,11/6/2025 6:30 PM,School Tour,,Elementary
-275134,Klondike Lane Elementary,(502) 485-8286,,,School Tour,Tours are 8/15-12/20,Elementary
-275145,Laukhuf Elementary,(502) 485-8289,,,School Tour,Tours are 10/27-12/12,Elementary
-275126,Layne Elementary,(502) 485-8290,,,School Tour,Tours are October-April,Elementary
-275520,Lincoln Elementary Performing Arts School,,10/27/2025 6:00 PM,,School Tour,,Elementary
-275520,Lincoln Elementary Performing Arts School,,11/18/2025 6:00 PM,,School Tour,,Elementary
-275146,Lowe Elementary,(502) 485-8293,,,School Tour,"Tours are 10/28, 10/29, 117, 11/14, and 12/5 ",Elementary
-275107,Luhr Elementary,(502) 485-8295,,,School Tour,,Elementary
-275480,Maupin Elementary,,11/19/2025 10:30 AM,11/19/2025 11:00 AM,School Tour,,Elementary
-275440,McFerran Preparatory Academy,(502) 485-8297,,,School Tour,Tours are 10:30-11:30 AM,Elementary
-275022,Medora Elementary,(502) 485-8298,,,School Tour,Tours are 10:30 AM-3:30 PM,Elementary
-275024,Middletown Elementary,(502) 485-8300,10/28/2025 10:30 AM,10/28/2025 11:30 AM,School Tour,Or Call to Schedule,Elementary
-275147,Mill Creek Elementary,(502) 485-8301,,,School Tour,,Elementary
-275099,Minors Lane Elementary,(502) 485-8303,,,School Tour,,Elementary
-275371,Norton Commons Elementary,(502) 485-8367,10/28/2025 10:45 AM,10/28/2025 11:45 AM,School Tour,Or Call to Schedule,Elementary
-275371,Norton Commons Elementary,(502) 485-8367,10/28/2025 3:00 PM,10/28/2025 4:00 PM,School Tour,Or Call to Schedule,Elementary
-275371,Norton Commons Elementary,(502) 485-8367,10/30/2025 8:00 AM,10/30/2025 9:00 AM,School Tour,Or Call to Schedule,Elementary
-275371,Norton Commons Elementary,(502) 485-8367,10/30/2025 5:00 PM,10/30/2025 6:00 PM,School Tour,Or Call to Schedule,Elementary
-275096,Norton Elementary,,10/30/2025 8:30 AM,10/30/2025 10:00 AM,School Tour,,Elementary
-275096,Norton Elementary,,11/5/2025 8:30 AM,11/5/2025 10:00 AM,School Tour,,Elementary
-275027,Okolona Elementary,(502) 485-8309,,,School Tour,,Elementary
-275182,Perry Elementary,(502) 485-8348,,,School Tour,,Elementary
-275500,Portland Elementary,(502) 485-8313,,,School Tour,,Elementary
-275128,Price Elementary,(502) 485-8315,,,School Tour,,Elementary
-275081,Rangeland Elementary,(502) 485-8317,,,School Tour,,Elementary
-275560,Rutherford Elementary,(502) 485-8320,,,School Tour,,Elementary
-275086,Sanders Elementary,(502) 485-8322,,,School Tour,,Elementary
-275063,Schaffner Traditional Elementary,(502) 485-8217,,,School Tour,Tours are 10/27-12/12,Elementary
-275580,Semple Elementary,(502) 485-8324,,,School Tour,,Elementary
-275097,Shacklette Elementary,(502) 485-8325,,,School Tour,,Elementary
-275610,Shelby Academy,(502) 485-8327,,,School Tour,,Elementary
-275103,Slaughter Elementary,(502) 485-8328,,,School Tour,,Elementary
-275087,Smyrna Elementary,(502) 485-8329,,,School Tour,Tours are 10/27-12/12,Elementary
-275064,St. Matthews Elementary,,11/10/2025 8:00 AM,,School Tour,,Elementary
-275064,St. Matthews Elementary,,11/18/2025 8:00 AM,,School Tour,,Elementary
-275064,St. Matthews Elementary,,12/4/2025 8:00 AM,,School Tour,,Elementary
-275071,Stonestreet Elementary,(502) 485-8333,,,School Tour,,Elementary
-275211,Stopher Elementary,,9/18/2025 10:00 AM,9/18/2025 11:00 AM,School Tour,Register Via this Link,Elementary
-275211,Stopher Elementary,,10/14/2025 10:00 AM,10/14/2025 11:00 AM,School Tour,Register Via this Link,Elementary
-275211,Stopher Elementary,,10/16/2025 10:00 AM,10/16/2025 11:00 AM,School Tour,Register Via this Link,Elementary
-275211,Stopher Elementary,,11/18/2025 10:00 AM,11/18/2025 11:00 AM,School Tour,Register Via this Link,Elementary
-275211,Stopher Elementary,,12/9/2025 10:00 AM,12/9/2025 11:00 AM,School Tour,Register Via this Link,Elementary
-275211,Stopher Elementary,,12/16/2025 10:00 AM,12/16/2025 11:00 AM,School Tour,Register Via this Link,Elementary
-275104,Trunnell Elementary,(502) 485-8337,,,School Tour,,Elementary
-275016,Tully Elementary,,11/11/2025 9:00 AM,,School Tour,,Elementary
-275016,Tully Elementary,,11/13/2025 9:00 AM,,School Tour,,Elementary
-275016,Tully Elementary,,11/18/2025 9:00 AM,,School Tour,,Elementary
-275016,Tully Elementary,,12/2/2025 9:00 AM,,School Tour,,Elementary
-275016,Tully Elementary,,12/4/2025 9:00 AM,,School Tour,,Elementary
-275072,Watterson Elementary,(502) 485-8342,10/11/2025 8:30 AM,,School Tour,Or Call to Schedule,Elementary
-275116,Wellington Elementary,(502) 485-8343,,,School Tour,,Elementary
-275109,Wheeler Elementary,,10/30/2025 8:30 AM,,School Tour,,Elementary
-275109,Wheeler Elementary,,11/14/2025 8:30 AM,,School Tour,,Elementary
-275109,Wheeler Elementary,,11/12/2025 8:30 AM,,School Tour,,Elementary
-275109,Wheeler Elementary,,12/9/2025 8:30 AM,,School Tour,,Elementary
-275109,Wheeler Elementary,,12/17/2025 8:30 AM,,School Tour,,Elementary
-275067,Wilder Elementary,,10/30/2025 8:30 AM,10/30/2025 9:30 AM,School Tour,,Elementary
-275067,Wilder Elementary,,11/12/2025 8:30 AM,11/12/2025 9:30 AM,School Tour,,Elementary
-275067,Wilder Elementary,,11/24/2025 8:30 AM,11/24/2025 9:30 AM,School Tour,,Elementary
-275066,Wilkerson Elementary,(502) 485-8351,,,School Tour,Tours are 8:00 AM-1:00 PM,Elementary
-275117,Wilt Elementary,(502) 485-8353,,,School Tour,Tours are 10/27-12/12,Elementary
-275374,Young Elementary at Engelhard,(502) 485-8246,,,School Tour,,Elementary
-275078,Zachary Taylor Elementary,(502) 485-8336,,,School Tour,,Elementary
-275040,Barret Traditional Middle,(502) 485-8207,11/18/2025 5:30 PM,11/18/2025 7:30 PM,Open House,,Middle
-275040,Barret Traditional Middle,(502) 485-8207,12/3/2025 8:00 AM,12/3/2025 9:00 AM,School Tour,Submit form to sign up,Middle
-275040,Barret Traditional Middle,(502) 485-8207,12/3/2025 9:30 AM,12/3/2025 10:30 AM,School Tour,Submit form to sign up,Middle
-275040,Barret Traditional Middle,(502) 485-8207,12/10/2025 8:00 AM,12/10/2025 9:00 AM,School Tour,Submit form to sign up,Middle
-275040,Barret Traditional Middle,(502) 485-8207,12/10/2025 9:30 AM,12/10/2025 10:30 AM,School Tour,Submit form to sign up,Middle
-275167,Carrithers Middle,(502) 485-8224,11/13/2025 6:00 PM,11/13/2025 7:00 PM,Open House,Or Call to Schedule a Visit,Middle
-275164,Conway Middle,(502) 485-8233,,,School Tour,,Middle
-275119,Crosby Middle,,11/5/2025 5:30 PM,11/5/2025 7:30 PM,School Tour,,Middle
-2751911,W.E.B. DuBois Academy,,10/20/2025 9:00 AM,10/20/2025 10:00 AM,School Tour,,Middle
-2751911,W.E.B. DuBois Academy,,10/29/2025 9:00 AM,10/29/2025 10:00 AM,School Tour,,Middle
-2751911,W.E.B. DuBois Academy,,11/5/2025 6:00 PM,11/5/2025 7:00 PM,School Tour,,Middle
-2751911,W.E.B. DuBois Academy,,11/12/2025 9:00 AM,11/12/2025 10:00 AM,School Tour,,Middle
-2751911,W.E.B. DuBois Academy,,11/19/2025 9:00 AM,11/19/2025 10:00 AM,School Tour,,Middle
-275255,Echo Trail Middle School,,11/6/2025 5:00 PM,,Open House,,Middle
-275255,Echo Trail Middle School,,11/6/2025 5:30 PM,,Open House,,Middle
-275255,Echo Trail Middle School,,11/6/2025 6:00 PM,,Open House,,Middle
-275255,Echo Trail Middle School,,11/6/2025 6:30 PM,,Open House,,Middle
-275255,Echo Trail Middle School,,11/6/2025 7:00 PM,,Open House,,Middle
-275255,Echo Trail Middle School,,11/13/2025 7:45 AM,,School Tour,,Middle
-275255,Echo Trail Middle School,,11/18/2025 7:45 AM,,School Tour,,Middle
-275255,Echo Trail Middle School,,11/20/2025 7:45 AM,,School Tour,,Middle
-275255,Echo Trail Middle School,,12/2/2025 7:45 AM,,School Tour,,Middle
-275255,Echo Trail Middle School,,12/4/2025 7:45 AM,,School Tour,,Middle
-275255,Echo Trail Middle School,,12/9/2025 7:45 AM,,School Tour,,Middle
-275255,Echo Trail Middle School,,12/11/2025 7:45 AM,,School Tour,,Middle
-275255,Echo Trail Middle School,,2/5/2026 7:45 AM,,School Tour,,Middle
-275255,Echo Trail Middle School,,3/12/2026 7:45 AM,,School Tour,,Middle
-275049,Farnsley Middle,,10/30/2025 6:00 PM,10/30/2025 7:30 PM,Open House,,Middle
-2758001,Grace M. James Academy of Excellence,,11/4/2025 6:30 PM,,Open House,,Middle
-275320,Highland Middle,,10/28/2025 9:00 AM,10/28/2025 10:00 AM,School Tour,,Middle
-275320,Highland Middle,,11/5/2025 9:00 AM,11/5/2025 10:00 AM,School Tour,,Middle
-275320,Highland Middle,,11/11/2025 9:00 AM,11/11/2025 10:00 AM,School Tour,,Middle
-275320,Highland Middle,,11/13/2025 5:30 PM,11/13/2025 7:30 PM,Open House,,Middle
-275406,Hudson Middle School,(502) 485-8187,,,School Tour,,Middle
-27516511,J. Graham Brown School,,11/7/2025 8:30 AM,,School Tour,,Middle
-27516511,J. Graham Brown School,,11/11/2025 8:30 AM,,School Tour,,Middle
-27516511,J. Graham Brown School,,11/18/2025 8:30 AM,,School Tour,,Middle
-27516511,J. Graham Brown School,,12/5/2025 8:30 AM,,School Tour,,Middle
-27516511,J. Graham Brown School,,12/17/2025 8:30 AM,,School Tour,,Middle
-275396,Jefferson County Traditional Middle,,11/17/2025 6:00 PM,11/17/2025 7:30 PM,School Tour,,Middle
-275470,Johnson Traditional Middle,,10/30/2025 9:00 AM,10/30/2025 10:00 AM,Open House,Call to confirm time,Middle
-275470,Johnson Traditional Middle,,11/6/2025 9:00 AM,11/6/2025 10:00 AM,School Tour,,Middle
-275470,Johnson Traditional Middle,,11/13/2025 9:00 AM,11/13/2025 10:00 AM,School Tour,,Middle
-275470,Johnson Traditional Middle,,11/20/2025 9:00 AM,11/20/2025 10:00 AM,School Tour,,Middle
-275470,Johnson Traditional Middle,,12/4/2025 9:00 AM,12/4/2025 10:00 AM,School Tour,,Middle
-275162,Kammerer Middle,,10/30/2025 5:30 PM,10/30/2025 7:00 PM,Open House,,Middle
-275163,Knight Middle,(502) 485-8287,,,School Tour,,Middle
-275133,Lassiter Middle,(502) 485-8288,,,School Tour,,Middle
-275340,Meyzeek Middle,(502) 485-8299,11/5/2025 5:30 PM,11/5/2025 7:30 PM,Open House,,Middle
-275340,Meyzeek Middle,(502) 485-8299,,,School Tour,Tours are M-F from 9:00-10:30 AM,Middle
-275041,Newburg Middle,,10/31/2025 9:00 AM,10/31/2025 10:00 AM,School Tour,,Middle
-275041,Newburg Middle,,11/7/2025 9:00 AM,11/7/2025 10:00 AM,School Tour,,Middle
-275041,Newburg Middle,,11/13/2025 5:30 PM,11/13/2025 7:00 PM,Open House,,Middle
-275041,Newburg Middle,,11/14/2025 9:00 AM,11/14/2025 10:00 AM,School Tour,,Middle
-275041,Newburg Middle,,11/21/2025 9:00 AM,11/21/2025 10:00 AM,School Tour,,Middle
-275041,Newburg Middle,,12/5/2025 9:00 AM,12/5/2025 10:00 AM,School Tour,,Middle
-275041,Newburg Middle,,12/12/2025 9:00 AM,12/12/2025 10:00 AM,School Tour,,Middle
-275041,Newburg Middle,,12/19/2025 9:00 AM,12/19/2025 10:00 AM,School Tour,,Middle
-275186,Newcomer Academy,(502) 398-3125,,,School Tour,Tours are 8:00 AM-2:00 PM,Middle
-275435,Noe Middle,,11/6/2025 6:00 PM,,Open House,,Middle
-275435,Noe Middle,,11/12/2025 9:30 AM,,School Tour,,Middle
-275435,Noe Middle,,11/14/2025 9:30 AM,,School Tour,,Middle
-275435,Noe Middle,,11/18/2025 9:30 AM,,School Tour,,Middle
-275620,Olmsted Academy North,(502) 485-8331,,,School Tour,,Middle
-275730,Olmsted Academy South,,10/28/2025 9:05 AM,10/28/2025 9:45 AM,School Tour,Submit form to sign up,Middle
-275730,Olmsted Academy South,,11/18/2025 9:05 AM,11/18/2025 9:45 AM,School Tour,Submit form to sign up,Middle
-275730,Olmsted Academy South,,12/3/2025 9:05 AM,12/3/2025 9:45 AM,School Tour,Submit form to sign up,Middle
-275730,Olmsted Academy South,,12/9/2025 9:05 AM,12/9/2025 9:45 AM,School Tour,Submit form to sign up,Middle
-2752011,Phoenix School of Discovery,(502) 212-4547,,,School Tour,,Middle
-275219,Ramsey Middle,(502) 485-8391,11/4/2025 5:30 PM,11/4/2025 7:00 PM,School Tour,Or Call to Schedule a Visit,Middle
-275144,Stuart Middle School,,11/10/2025 5:30 PM,11/10/2025 7:00 PM,School Tour,,Middle
-275090,Thomas Jefferson Middle,(502) 485-8273,,,School Tour,,Middle
-275710,Western Middle School for the Arts,,10/29/2025 7:00 PM,,Open House,,Middle
-275710,Western Middle School for the Arts,,11/12/2025 9:00 AM,,School Tour,,Middle
-275710,Western Middle School for the Arts,,11/17/2025 12:00 PM,,School Tour,,Middle
-275710,Western Middle School for the Arts,,11/19/2025 9:00 AM,,School Tour,,Middle
-275710,Western Middle School for the Arts,,11/24/2025 12:00 PM,,School Tour,,Middle
-275710,Western Middle School for the Arts,,12/3/2025 9:00 AM,,School Tour,,Middle
-275710,Western Middle School for the Arts,,12/8/2025 12:00 PM,,School Tour,,Middle
-275710,Western Middle School for the Arts,,12/10/2025 9:00 AM,,School Tour,,Middle
-275077,Westport Middle,,11/6/2025 5:30 PM,11/6/2025 7:00 PM,Open House,,Middle
-275077,Westport Middle,,,,School Tour,Tours on select Tuesdays/Thursdays at 9:00 AM. See Westport Website for School Tour Sign Up,Middle
-275049,Farnsley Middle,,11/4/2025 8:45 AM,11/4/2025 9:30 AM,School Tour,Submit form to sign up,Middle
-275049,Farnsley Middle,,11/6/2025 8:45 AM,11/6/2025 9:30 AM,School Tour,Submit form to sign up,Middle
-275049,Farnsley Middle,,11/11/2025 8:45 AM,11/11/2025 9:30 AM,School Tour,Submit form to sign up,Middle
-275049,Farnsley Middle,,11/13/2025 8:45 AM,11/13/2025 9:30 AM,School Tour,Submit form to sign up,Middle
-275049,Farnsley Middle,,11/18/2025 8:45 AM,11/18/2025 9:30 AM,School Tour,Submit form to sign up,Middle
-275049,Farnsley Middle,,11/20/2025 8:45 AM,11/20/2025 9:30 AM,School Tour,Submit form to sign up,Middle
-275049,Farnsley Middle,,11/25/2025 8:45 AM,11/25/2025 9:30 AM,School Tour,Submit form to sign up,Middle
-2758001,Grace M. James Academy of Excellence,,10/22/2025 1:00 PM,10/22/2025 2:00 PM,School Tour,Submit form to sign up,Middle
-2758001,Grace M. James Academy of Excellence,,11/19/2025 1:00 PM,11/19/2025 2:00 PM,School Tour,Submit form to sign up,Middle
-2758001,Grace M. James Academy of Excellence,,12/3/2025 1:00 PM,12/3/2025 2:00 PM,School Tour,Submit form to sign up,Middle
-2758001,Grace M. James Academy of Excellence,,12/10/2025 1:00 PM,12/10/2025 2:00 PM,School Tour,Submit form to sign up,Middle
-2758001,Grace M. James Academy of Excellence,,12/17/2025 1:00 PM,12/17/2025 2:00 PM,School Tour,Submit form to sign up,Middle
-2758001,Grace M. James Academy of Excellence,,1/21/2026 1:00 PM,1/21/2026 2:00 PM,School Tour,Submit form to sign up,Middle
-2758001,Grace M. James Academy of Excellence,,2/18/2026 1:00 PM,2/18/2026 2:00 PM,School Tour,Submit form to sign up,Middle
-275018,Atherton High,,10/30/2025 6:00 PM,,Open House,,High
-275105,Ballard High,,11/6/2025 6:30 PM,,Open House,More Information and sign up,High
-2751652,J. Graham Brown School,,11/7/2025 8:30 AM,,School Tour,,High
-2751652,J. Graham Brown School,,11/11/2025 8:30 AM,,School Tour,,High
-2751652,J. Graham Brown School,,11/18/2025 8:30 AM,,School Tour,,High
-2751652,J. Graham Brown School,,12/5/2025 8:30 AM,,School Tour,,High
-2751652,J. Graham Brown School,,12/17/2025 8:30 AM,,School Tour,,High
-275045,Butler Traditional High,,11/11/2025 5:30 PM,,Open House,,High
-275179,Central High Magnet Career Academy,,10/29/2025 8:30 AM,,School Tour,,High
-275179,Central High Magnet Career Academy,,11/6/2025 6:00 PM,,Open House,,High
-275179,Central High Magnet Career Academy,,11/12/2025 8:30 AM,,School Tour,,High
-275179,Central High Magnet Career Academy,,11/19/2025 8:30 AM,,School Tour,,High
-275179,Central High Magnet Career Academy,,12/3/2025 8:30 AM,,School Tour,,High
-275179,Central High Magnet Career Academy,,12/10/2025 8:30 AM,,School Tour,,High
-275100,Doss High,,11/3/2025 1:00 PM,11/3/2025 3:00 PM,Open House,,High
-2752002,DuPont Manual High,,10/9/2025 1:00 PM,10/9/2025 3:00 PM,School Tour,,High
-2752002,DuPont Manual High,,10/16/2025 1:00 PM,10/16/2025 3:00 PM,School Tour,,High
-2752002,DuPont Manual High,,10/23/2025 1:00 PM,10/23/2025 3:00 PM,School Tour,,High
-2752002,DuPont Manual High,,10/28/2025 6:00 PM,,Open House,,High
-2752002,DuPont Manual High,,10/30/2025 1:00 PM,10/30/2025 3:00 PM,School Tour,,High
-2752002,DuPont Manual High,,11/6/2025 1:00 PM,11/6/2025 3:00 PM,School Tour,,High
-2752002,DuPont Manual High,,11/13/2025 1:00 PM,11/13/2025 3:00 PM,School Tour,,High
-275007,Eastern High,,11/4/2025 6:00 PM,,Open House,,High
-275012,Fern Creek High,,12/9/2025 6:00 PM,,Open House,,High
-275057,Fairdale High,,11/11/2025 9:00 AM,11/11/2025 12:00 PM,School Tour,Submit form to sign up,High
-275057,Fairdale High,,11/13/2025 9:00 AM,11/13/2025 12:00 PM,School Tour,Submit form to sign up,High
-275335,Iroquois High,,11/13/2025 5:30 PM,,Open House,,High
-2758002,Grace M. James Academy of Excellence,,11/4/2025 6:30 PM,,Open House,,High
-275065,Jeffersontown High,(502) 485-8275,,,School Tour,,High
-275047,Louisville Male High,,11/13/2025 6:00 PM,,Open House,,High
-2751552,Marion C. Moore School,(502) 485-8304,,,School Tour,,High
-2752012,Phoenix School of Discovery,(502) 212-4547,,,School Tour,,High
-275075,Pleasure Ridge Park High,(502) 485-8311,,,School Tour,Tours are 9-11 AM and 1-3 PM,High
-275073,Seneca High,,12/1/2025 6:30 PM,,Open House,,High
-2755902,The Academy @ Shawnee,,11/3/2025 1:00 PM,11/3/2025 4:00 PM,Open House,,High
-275031,Southern High,,10/30/2025 6:00 PM,10/30/2025 7:00 PM,Open House,,High
-275033,Valley High,,11/3/2025 1:00 PM,11/3/2025 3:00 PM,Open House,,High
-275033,Valley High,,11/4/2025 9:00 AM,11/4/2025 11:00 AM,Open House,,High
-275051,Waggener High,,10/29/2025 6:00 PM,10/29/2025 7:30 PM,Open House,,High
-275084,Western High,(502) 485-8344,11/5/2025 6:30 PM,11/5/2025 8:00 PM,Open House,Or Call to Schedule a Visit,High
-275105,Ballard High,,9/22/2025 4:00 PM,9/22/2025 4:30 PM,School Tour,After school tour. More Information and sign up,High
-275105,Ballard High,,10/16/2025 4:00 PM,10/16/2025 4:30 PM,School Tour,After school tour. More Information and sign up,High
-275105,Ballard High,,10/27/2025 4:00 PM,10/27/2025 4:30 PM,School Tour,After school tour. More Information and sign up,High
-275105,Ballard High,,11/4/2025 4:00 PM,11/4/2025 4:30 PM,School Tour,After school tour. More Information and sign up,High
-275105,Ballard High,,11/20/2025 4:00 PM,11/20/2025 4:30 PM,School Tour,After school tour. More Information and sign up,High
-275105,Ballard High,,12/4/2025 4:00 PM,12/4/2025 4:30 PM,School Tour,After school tour. More Information and sign up,High
-275105,Ballard High,,9/25/2025 9:00 AM,9/25/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-275105,Ballard High,,10/7/2025 9:00 AM,10/7/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-275105,Ballard High,,10/9/2025 9:00 AM,10/9/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-275105,Ballard High,,10/14/2025 9:00 AM,10/14/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-275105,Ballard High,,10/16/2025 9:00 AM,10/16/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-275105,Ballard High,,10/23/2025 9:00 AM,10/23/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-275105,Ballard High,,10/28/2025 9:00 AM,10/28/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-275105,Ballard High,,10/30/2025 9:00 AM,10/30/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-275105,Ballard High,,11/6/2025 9:00 AM,11/6/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-275105,Ballard High,,11/11/2025 9:00 AM,11/11/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-275105,Ballard High,,11/13/2025 9:00 AM,11/13/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-275105,Ballard High,,11/18/2025 9:00 AM,11/18/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-275105,Ballard High,,11/20/2025 9:00 AM,11/20/2025 11:00 AM,School Tour,Shadow Visit. More information and sign up,High
-2758002,Grace M. James Academy of Excellence,,10/22/2025 1:00 PM,10/22/2025 2:00 PM,School Tour,Submit form to sign up,High
-2758002,Grace M. James Academy of Excellence,,11/19/2025 1:00 PM,11/19/2025 2:00 PM,School Tour,Submit form to sign up,High
-2758002,Grace M. James Academy of Excellence,,12/3/2025 1:00 PM,12/3/2025 2:00 PM,School Tour,Submit form to sign up,High
-2758002,Grace M. James Academy of Excellence,,12/10/2025 1:00 PM,12/10/2025 2:00 PM,School Tour,Submit form to sign up,High
-2758002,Grace M. James Academy of Excellence,,12/17/2025 1:00 PM,12/17/2025 2:00 PM,School Tour,Submit form to sign up,High
-2758002,Grace M. James Academy of Excellence,,1/21/2026 1:00 PM,1/21/2026 2:00 PM,School Tour,Submit form to sign up,High
-2758002,Grace M. James Academy of Excellence,,2/18/2026 1:00 PM,2/18/2026 2:00 PM,School Tour,Submit form to sign up,High
+School Code Adjusted,School Name,Phone,Start Time,End Time,Type,Notes,Level,Registration link
+275175,Alex R. Kennedy Elementary,(502) 485-6950,,,School Tour,Tours are 11:00 AM-2:00 PM,Elementary,
+275185,Atkinson Elementary,(502) 485-8203,,,School Tour,Tours are 9:40-11:00 AM,Elementary,
+275127,Auburndale Elementary,(502) 485-8204,,,School Tour,Tours are 8:00-9:00 AM,Elementary,
+275044,Audubon Traditional Elementary,,11/5/2025 10:30 AM,11/5/2025 11:30 AM,School Tour,,Elementary,
+275044,Audubon Traditional Elementary,,11/11/2025 5:30 PM,11/11/2025 6:30 PM,School Tour,,Elementary,
+275044,Audubon Traditional Elementary,,11/12/2025 10:30 AM,11/12/2025 11:30 AM,School Tour,,Elementary,
+275044,Audubon Traditional Elementary,,11/19/2025 10:30 AM,11/19/2025 11:30 AM,School Tour,,Elementary,
+275055,Bates Elementary,,10/16/2025 10:30 AM,10/16/2025 11:30 AM,School Tour,,Elementary,
+275055,Bates Elementary,,10/16/2025 1:30 PM,10/16/2025 2:30 PM,School Tour,,Elementary,
+275055,Bates Elementary,,10/23/2025 10:30 AM,10/23/2025 11:30 AM,School Tour,,Elementary,
+275055,Bates Elementary,,10/23/2025 1:30 PM,10/23/2025 2:30 PM,School Tour,,Elementary,
+275055,Bates Elementary,,10/30/2025 10:30 AM,10/30/2025 11:30 AM,School Tour,,Elementary,
+275055,Bates Elementary,,10/30/2025 1:30 PM,10/30/2025 2:30 PM,School Tour,,Elementary,
+275055,Bates Elementary,,11/6/2025 10:30 AM,11/6/2025 11:30 AM,School Tour,,Elementary,
+275055,Bates Elementary,,11/6/2025 1:30 PM,11/6/2025 2:30 PM,School Tour,,Elementary,
+275055,Bates Elementary,,11/13/2025 10:30 AM,11/13/2025 11:30 AM,School Tour,,Elementary,
+275055,Bates Elementary,,11/13/2025 1:30 PM,11/13/2025 2:30 PM,School Tour,,Elementary,
+275055,Bates Elementary,,11/20/2025 10:30 AM,11/20/2025 11:30 AM,School Tour,,Elementary,
+275055,Bates Elementary,,11/20/2025 1:30 PM,11/20/2025 2:30 PM,School Tour,,Elementary,
+275055,Bates Elementary,,12/4/2025 10:30 AM,12/4/2025 11:30 AM,School Tour,,Elementary,
+275055,Bates Elementary,,12/4/2025 1:30 PM,12/4/2025 2:30 PM,School Tour,,Elementary,
+275055,Bates Elementary,,12/11/2025 10:30 AM,12/11/2025 11:30 AM,School Tour,,Elementary,
+275055,Bates Elementary,,12/11/2025 1:30 PM,12/11/2025 2:30 PM,School Tour,,Elementary,
+275149,Blake Elementary,(502) 485-8210,,,School Tour,Tours are 7:30-9:30 AM,Elementary,
+275225,Bloom Elementary,,11/3/2025 2:00 PM,,School Tour,,Elementary,
+275091,Blue Lick Elementary,(502) 485-8212,,,School Tour,,Elementary,
+275094,Bowen Elementary,(502) 485-8213,,,School Tour,Tours are 11:00 AM-2:00 PM,Elementary,
+275260,Brandeis Elementary,,10/29/2025 10:00 AM,10/29/2025 11:00 AM,School Tour,,Elementary,
+275260,Brandeis Elementary,,10/29/2025 12:00 PM,10/29/2025 1:00 PM,School Tour,,Elementary,
+275260,Brandeis Elementary,,11/5/2025 10:00 AM,11/5/2025 11:00 AM,School Tour,,Elementary,
+275260,Brandeis Elementary,,11/5/2025 12:00 PM,11/5/2025 1:00 PM,School Tour,,Elementary,
+275260,Brandeis Elementary,,11/12/2025 10:00 AM,11/12/2025 11:00 AM,School Tour,,Elementary,
+275260,Brandeis Elementary,,11/12/2025 12:00 PM,11/12/2025 1:00 PM,School Tour,,Elementary,
+275260,Brandeis Elementary,,11/19/2025 10:00 AM,11/19/2025 11:00 AM,School Tour,,Elementary,
+275260,Brandeis Elementary,,11/19/2025 12:00 PM,11/19/2025 1:00 PM,School Tour,,Elementary,
+275260,Brandeis Elementary,,12/3/2025 10:00 AM,12/3/2025 11:00 AM,School Tour,,Elementary,
+275260,Brandeis Elementary,,12/3/2025 12:00 PM,12/3/2025 1:00 PM,School Tour,,Elementary,
+275260,Brandeis Elementary,,12/10/2025 10:00 AM,12/10/2025 11:00 AM,School Tour,,Elementary,
+275260,Brandeis Elementary,,12/10/2025 12:00 PM,12/10/2025 1:00 PM,School Tour,,Elementary,
+275260,Brandeis Elementary,,12/17/2025 10:00 AM,12/17/2025 11:00 AM,School Tour,,Elementary,
+275260,Brandeis Elementary,,12/17/2025 12:00 PM,12/17/2025 1:00 PM,School Tour,,Elementary,
+275038,Breckinridge-Franklin,(502) 485-8215,,,School Tour,Tours are 10:00 AM-3:00 PM and 4:45-5:15 PM,Elementary,
+275243,Byck Elementary,(502) 485-8221,,,School Tour,Tours are 10:30 AM-2:00 PM,Elementary,
+275004,Camp Taylor Elementary,(502)485-8222,,,School Tour,Tours are 8:00 AM - 1:00 PM,Elementary,
+275005,Cane Run Elementary,(502) 485-8223,,,School Tour,,Elementary,
+275680,Carter Traditional Elementary,(502) 485-8225,,,School Tour,,Elementary,
+275102,Chancey Elementary,,10/8/2025 8:30 AM,,School Tour,,Elementary,
+275102,Chancey Elementary,,10/15/2025 8:30 AM,,School Tour,,Elementary,
+275102,Chancey Elementary,,10/22/2025 8:30 AM,,School Tour,,Elementary,
+275102,Chancey Elementary,,10/29/2025 8:30 AM,,School Tour,,Elementary,
+275046,Chenoweth Elementary,,10/29/2025 10:00 AM,10/29/2025 11:00 AM,School Tour,,Elementary,
+275046,Chenoweth Elementary,,11/5/2025 10:00 AM,11/5/2025 11:00 AM,School Tour,,Elementary,
+275046,Chenoweth Elementary,,11/12/2025 10:00 AM,11/12/2025 11:00 AM,School Tour,,Elementary,
+275323,Cochran Elementary,(502) 485-8230,,,School Tour,,Elementary,
+275083,Cochrane Elementary,,11/4/2025 2:45 PM,,School Tour,,Elementary,
+275660,Coleridge-Taylor,,10/15/2025 10:00 AM,,School Tour,,Elementary,
+275660,Coleridge-Taylor,,10/22/2025 10:00 AM,,School Tour,,Elementary,
+275660,Coleridge-Taylor,,10/29/2025 10:00 AM,,School Tour,,Elementary,
+275660,Coleridge-Taylor,,11/5/2025 10:00 AM,,School Tour,,Elementary,
+275660,Coleridge-Taylor,,11/12/2025 10:00 AM,,School Tour,,Elementary,
+275660,Coleridge-Taylor,,11/19/2025 10:00 AM,,School Tour,,Elementary,
+275660,Coleridge-Taylor,,11/26/2025 10:00 AM,,School Tour,,Elementary,
+275660,Coleridge-Taylor,,12/3/2025 10:00 AM,,School Tour,,Elementary,
+275660,Coleridge-Taylor,,12/10/2025 10:00 AM,,School Tour,,Elementary,
+275660,Coleridge-Taylor,,12/17/2025 10:00 AM,,School Tour,,Elementary,
+275060,Coral Ridge Elementary,(502) 485-8234,,,School Tour,,Elementary,
+275092,Crums Lane Elementary,(502) 485-8236,,,School Tour,,Elementary,
+275082,Dixie Elementary,(502) 485-8238,,,School Tour,,Elementary,
+275156,Dunn Elementary,(502) 485-8240,,,School Tour,"Tours are  9/9, 10/10, 11/6, 12/5 ",Elementary,
+275131,Eisenhower Elementary,(502) 485-8244,,,School Tour,,Elementary,
+275010,Fairdale Elementary,(502) 485-8247,,,School Tour,,Elementary,
+275212,Farmer Elementary,,10/28/2025 10:15 AM,,School Tour,,Elementary,
+275212,Farmer Elementary,,11/13/2025 10:15 AM,,School Tour,,Elementary,
+275011,Fern Creek Elementary,(502) 485-8250,11/13/2025 10:15 AM,,School Tour,Call to schedule alternate day,Elementary,
+275250,Field Elementary,(502) 485-8252,,,School Tour,,Elementary,
+275270,Foster Traditional Academy,(502) 485-8253,,,School Tour,,Elementary,
+275290,Frayser Elementary,(502) 485-8255,,,School Tour,,Elementary,
+275061,Goldsmith Elementary,(502) 485-8258,,,School Tour,,Elementary,
+275013,Greathouse/Shryock Traditional Elementary,,10/29/2025 10:00 AM,10/29/2025 11:00 AM,School Tour,,Elementary,
+275013,Greathouse/Shryock Traditional Elementary,,11/6/2025 1:00 PM,11/6/2025 2:00 PM,School Tour,,Elementary,
+275013,Greathouse/Shryock Traditional Elementary,,11/10/2025 10:00 AM,11/10/2025 11:00 AM,School Tour,,Elementary,
+275013,Greathouse/Shryock Traditional Elementary,,12/2/2025 5:00 PM,12/2/2025 6:00 PM,School Tour,,Elementary,
+275014,Greenwood Elementary,(502) 485-8260,,,School Tour,,Elementary,
+275115,Gutermuth Elementary,(502) 485-8261,,,School Tour,,Elementary,
+275121,Hartstern Elementary,(502) 485-8262,,,School Tour,,Elementary,
+275048,Hawthorne Elementary,,11/6/2025 5:00 PM,11/6/2025 6:00 PM,School Tour,,Elementary,
+275048,Hawthorne Elementary,,11/11/2025 9:30 AM,11/11/2025 10:30 AM,School Tour,,Elementary,
+275048,Hawthorne Elementary,,12/4/2025 9:30 AM,12/4/2025 10:30 AM,School Tour,,Elementary,
+275048,Hawthorne Elementary,,12/9/2025 5:00 PM,12/9/2025 6:00 PM,School Tour,,Elementary,
+275300,Hazelwood Elementary,(502) 485-8264,,,School Tour,,Elementary,
+275095,Hite Elementary,,11/3/2025 11:30 AM,11/3/2025 1:00 PM,School Tour,,Elementary,
+275076,Indian Trail Elementary,(502) 485-8268,,,School Tour,,Elementary,
+2751651,J. Graham Brown School,,11/7/2025 8:30 AM,,School Tour,,Elementary,
+2751651,J. Graham Brown School,,11/11/2025 8:30 AM,,School Tour,,Elementary,
+2751651,J. Graham Brown School,,11/18/2025 8:30 AM,,School Tour,,Elementary,
+2751651,J. Graham Brown School,,12/5/2025 8:30 AM,,School Tour,,Elementary,
+2751651,J. Graham Brown School,,12/17/2025 8:30 AM,,School Tour,,Elementary,
+275325,Jacob Elementary,(502) 485-8271,,,School Tour,,Elementary,
+275166,Jeffersontown Elementary,(502) 485-8274,,,School Tour,,Elementary,
+275106,Johnsontown Road Elementary,(502) 485-8278,,,School Tour,,Elementary,
+275720,Kennedy Elementary,(502) 485-8280,,,School Tour,,Elementary,
+275059,Kenwood Elementary,(502) 485-8283,,,School Tour,,Elementary,
+275079,Kerrick Elementary,(502) 485-8284,,,School Tour,,Elementary,
+275432,King Elementary,,11/6/2025 5:00 PM,11/6/2025 6:30 PM,School Tour,,Elementary,
+275134,Klondike Lane Elementary,(502) 485-8286,,,School Tour,Tours are 8/15-12/20,Elementary,
+275145,Laukhuf Elementary,(502) 485-8289,,,School Tour,Tours are 10/27-12/12,Elementary,
+275126,Layne Elementary,(502) 485-8290,,,School Tour,Tours are October-April,Elementary,
+275520,Lincoln Elementary Performing Arts School,,10/27/2025 6:00 PM,,School Tour,,Elementary,
+275520,Lincoln Elementary Performing Arts School,,11/18/2025 6:00 PM,,School Tour,,Elementary,
+275146,Lowe Elementary,(502) 485-8293,,,School Tour,"Tours are 10/28, 10/29, 117, 11/14, and 12/5 ",Elementary,
+275107,Luhr Elementary,(502) 485-8295,,,School Tour,,Elementary,
+275480,Maupin Elementary,,11/19/2025 10:30 AM,11/19/2025 11:00 AM,School Tour,,Elementary,
+275440,McFerran Preparatory Academy,(502) 485-8297,,,School Tour,Tours are 10:30-11:30 AM,Elementary,
+275022,Medora Elementary,(502) 485-8298,,,School Tour,Tours are 10:30 AM-3:30 PM,Elementary,
+275024,Middletown Elementary,(502) 485-8300,10/28/2025 10:30 AM,10/28/2025 11:30 AM,School Tour,Or call to schedule alternate day,Elementary,
+275147,Mill Creek Elementary,(502) 485-8301,,,School Tour,,Elementary,
+275099,Minors Lane Elementary,(502) 485-8303,,,School Tour,,Elementary,
+275371,Norton Commons Elementary,(502) 485-8367,10/28/2025 10:45 AM,10/28/2025 11:45 AM,School Tour,Or call to schedule alternate day,Elementary,
+275371,Norton Commons Elementary,(502) 485-8367,10/28/2025 3:00 PM,10/28/2025 4:00 PM,School Tour,Or call to schedule alternate day,Elementary,
+275371,Norton Commons Elementary,(502) 485-8367,10/30/2025 8:00 AM,10/30/2025 9:00 AM,School Tour,Or call to schedule alternate day,Elementary,
+275371,Norton Commons Elementary,(502) 485-8367,10/30/2025 5:00 PM,10/30/2025 6:00 PM,School Tour,Or call to schedule alternate day,Elementary,
+275096,Norton Elementary,,10/30/2025 8:30 AM,10/30/2025 10:00 AM,School Tour,,Elementary,
+275096,Norton Elementary,,11/5/2025 8:30 AM,11/5/2025 10:00 AM,School Tour,,Elementary,
+275027,Okolona Elementary,(502) 485-8309,,,School Tour,,Elementary,
+275182,Perry Elementary,(502) 485-8348,,,School Tour,,Elementary,
+275500,Portland Elementary,(502) 485-8313,,,School Tour,,Elementary,
+275128,Price Elementary,(502) 485-8315,,,School Tour,,Elementary,
+275081,Rangeland Elementary,(502) 485-8317,,,School Tour,,Elementary,
+275560,Rutherford Elementary,(502) 485-8320,,,School Tour,,Elementary,
+275086,Sanders Elementary,(502) 485-8322,,,School Tour,,Elementary,
+275063,Schaffner Traditional Elementary,(502) 485-8217,,,School Tour,Tours are 10/27-12/12,Elementary,
+275580,Semple Elementary,(502) 485-8324,,,School Tour,,Elementary,
+275097,Shacklette Elementary,(502) 485-8325,,,School Tour,,Elementary,
+275610,Shelby Academy,(502) 485-8327,,,School Tour,,Elementary,
+275103,Slaughter Elementary,(502) 485-8328,,,School Tour,,Elementary,
+275087,Smyrna Elementary,(502) 485-8329,,,School Tour,Tours are 10/27-12/12,Elementary,
+275064,St. Matthews Elementary,,11/10/2025 8:00 AM,,School Tour,,Elementary,
+275064,St. Matthews Elementary,,11/18/2025 8:00 AM,,School Tour,,Elementary,
+275064,St. Matthews Elementary,,12/4/2025 8:00 AM,,School Tour,,Elementary,
+275071,Stonestreet Elementary,(502) 485-8333,,,School Tour,,Elementary,
+275211,Stopher Elementary,,9/18/2025 10:00 AM,9/18/2025 11:00 AM,School Tour,,Elementary,[Register via this Link](https://www.signupgenius.com/go/10C0C48A8AE2FA6F5C43-50739498-stopher#/)
+275211,Stopher Elementary,,10/14/2025 10:00 AM,10/14/2025 11:00 AM,School Tour,,Elementary,[Register via this Link](https://www.signupgenius.com/go/10C0C48A8AE2FA6F5C43-50739498-stopher#/)
+275211,Stopher Elementary,,10/16/2025 10:00 AM,10/16/2025 11:00 AM,School Tour,,Elementary,[Register via this Link](https://www.signupgenius.com/go/10C0C48A8AE2FA6F5C43-50739498-stopher#/)
+275211,Stopher Elementary,,11/18/2025 10:00 AM,11/18/2025 11:00 AM,School Tour,,Elementary,[Register via this Link](https://www.signupgenius.com/go/10C0C48A8AE2FA6F5C43-50739498-stopher#/)
+275211,Stopher Elementary,,12/9/2025 10:00 AM,12/9/2025 11:00 AM,School Tour,,Elementary,[Register via this Link](https://www.signupgenius.com/go/10C0C48A8AE2FA6F5C43-50739498-stopher#/)
+275211,Stopher Elementary,,12/16/2025 10:00 AM,12/16/2025 11:00 AM,School Tour,,Elementary,[Register via this Link](https://www.signupgenius.com/go/10C0C48A8AE2FA6F5C43-50739498-stopher#/)
+275104,Trunnell Elementary,(502) 485-8337,,,School Tour,,Elementary,
+275016,Tully Elementary,,11/11/2025 9:00 AM,,School Tour,,Elementary,
+275016,Tully Elementary,,11/13/2025 9:00 AM,,School Tour,,Elementary,
+275016,Tully Elementary,,11/18/2025 9:00 AM,,School Tour,,Elementary,
+275016,Tully Elementary,,12/2/2025 9:00 AM,,School Tour,,Elementary,
+275016,Tully Elementary,,12/4/2025 9:00 AM,,School Tour,,Elementary,
+275072,Watterson Elementary,(502) 485-8342,10/11/2025 8:30 AM,,School Tour,,Elementary,
+275116,Wellington Elementary,(502) 485-8343,,,School Tour,,Elementary,
+275109,Wheeler Elementary,,10/30/2025 8:30 AM,,School Tour,,Elementary,
+275109,Wheeler Elementary,,11/14/2025 8:30 AM,,School Tour,,Elementary,
+275109,Wheeler Elementary,,11/12/2025 8:30 AM,,School Tour,,Elementary,
+275109,Wheeler Elementary,,12/9/2025 8:30 AM,,School Tour,,Elementary,
+275109,Wheeler Elementary,,12/17/2025 8:30 AM,,School Tour,,Elementary,
+275067,Wilder Elementary,,10/30/2025 8:30 AM,10/30/2025 9:30 AM,School Tour,,Elementary,
+275067,Wilder Elementary,,11/12/2025 8:30 AM,11/12/2025 9:30 AM,School Tour,,Elementary,
+275067,Wilder Elementary,,11/24/2025 8:30 AM,11/24/2025 9:30 AM,School Tour,,Elementary,
+275066,Wilkerson Elementary,(502) 485-8351,,,School Tour,Tours are 8:00 AM-1:00 PM,Elementary,
+275117,Wilt Elementary,(502) 485-8353,,,School Tour,Tours are 10/27-12/12,Elementary,
+275374,Young Elementary at Engelhard,(502) 485-8246,,,School Tour,,Elementary,
+275078,Zachary Taylor Elementary,(502) 485-8336,,,School Tour,,Elementary,
+275040,Barret Traditional Middle,(502) 485-8207,11/18/2025 5:30 PM,11/18/2025 7:30 PM,Open House,,Middle,
+275040,Barret Traditional Middle,(502) 485-8207,12/3/2025 8:00 AM,12/3/2025 9:00 AM,School Tour,,Middle,[Register via this link](https://docs.google.com/forms/d/e/1FAIpQLSfsIRIo159SIiPXIZKk2FKIBUCwXfCInLE3IbM5DAvbJhe0tA/viewform)
+275040,Barret Traditional Middle,(502) 485-8207,12/3/2025 9:30 AM,12/3/2025 10:30 AM,School Tour,,Middle,[Register via this link](https://docs.google.com/forms/d/e/1FAIpQLSfsIRIo159SIiPXIZKk2FKIBUCwXfCInLE3IbM5DAvbJhe0tA/viewform)
+275040,Barret Traditional Middle,(502) 485-8207,12/10/2025 8:00 AM,12/10/2025 9:00 AM,School Tour,,Middle,[Register via this link](https://docs.google.com/forms/d/e/1FAIpQLSfsIRIo159SIiPXIZKk2FKIBUCwXfCInLE3IbM5DAvbJhe0tA/viewform)
+275040,Barret Traditional Middle,(502) 485-8207,12/10/2025 9:30 AM,12/10/2025 10:30 AM,School Tour,,Middle,[Register via this link](https://docs.google.com/forms/d/e/1FAIpQLSfsIRIo159SIiPXIZKk2FKIBUCwXfCInLE3IbM5DAvbJhe0tA/viewform)
+275167,Carrithers Middle,(502) 485-8224,11/13/2025 6:00 PM,11/13/2025 7:00 PM,Open House,,Middle,
+275164,Conway Middle,(502) 485-8233,,,School Tour,,Middle,
+275119,Crosby Middle,,11/5/2025 5:30 PM,11/5/2025 7:30 PM,School Tour,,Middle,
+2751911,W.E.B. DuBois Academy,,10/20/2025 9:00 AM,10/20/2025 10:00 AM,School Tour,,Middle,
+2751911,W.E.B. DuBois Academy,,10/29/2025 9:00 AM,10/29/2025 10:00 AM,School Tour,,Middle,
+2751911,W.E.B. DuBois Academy,,11/5/2025 6:00 PM,11/5/2025 7:00 PM,School Tour,,Middle,
+2751911,W.E.B. DuBois Academy,,11/12/2025 9:00 AM,11/12/2025 10:00 AM,School Tour,,Middle,
+2751911,W.E.B. DuBois Academy,,11/19/2025 9:00 AM,11/19/2025 10:00 AM,School Tour,,Middle,
+275255,Echo Trail Middle School,,11/6/2025 5:00 PM,,Open House,,Middle,
+275255,Echo Trail Middle School,,11/6/2025 5:30 PM,,Open House,,Middle,
+275255,Echo Trail Middle School,,11/6/2025 6:00 PM,,Open House,,Middle,
+275255,Echo Trail Middle School,,11/6/2025 6:30 PM,,Open House,,Middle,
+275255,Echo Trail Middle School,,11/6/2025 7:00 PM,,Open House,,Middle,
+275255,Echo Trail Middle School,,11/13/2025 7:45 AM,,School Tour,,Middle,
+275255,Echo Trail Middle School,,11/18/2025 7:45 AM,,School Tour,,Middle,
+275255,Echo Trail Middle School,,11/20/2025 7:45 AM,,School Tour,,Middle,
+275255,Echo Trail Middle School,,12/2/2025 7:45 AM,,School Tour,,Middle,
+275255,Echo Trail Middle School,,12/4/2025 7:45 AM,,School Tour,,Middle,
+275255,Echo Trail Middle School,,12/9/2025 7:45 AM,,School Tour,,Middle,
+275255,Echo Trail Middle School,,12/11/2025 7:45 AM,,School Tour,,Middle,
+275255,Echo Trail Middle School,,2/5/2026 7:45 AM,,School Tour,,Middle,
+275255,Echo Trail Middle School,,3/12/2026 7:45 AM,,School Tour,,Middle,
+275049,Farnsley Middle,,10/30/2025 6:00 PM,10/30/2025 7:30 PM,Open House,,Middle,
+2758001,Grace M. James Academy of Excellence,,11/4/2025 6:30 PM,,Open House,,Middle,
+275320,Highland Middle,,10/28/2025 9:00 AM,10/28/2025 10:00 AM,School Tour,,Middle,
+275320,Highland Middle,,11/5/2025 9:00 AM,11/5/2025 10:00 AM,School Tour,,Middle,
+275320,Highland Middle,,11/11/2025 9:00 AM,11/11/2025 10:00 AM,School Tour,,Middle,
+275320,Highland Middle,,11/13/2025 5:30 PM,11/13/2025 7:30 PM,Open House,,Middle,
+275406,Hudson Middle School,(502) 485-8187,,,School Tour,,Middle,
+27516511,J. Graham Brown School,,11/7/2025 8:30 AM,,School Tour,,Middle,
+27516511,J. Graham Brown School,,11/11/2025 8:30 AM,,School Tour,,Middle,
+27516511,J. Graham Brown School,,11/18/2025 8:30 AM,,School Tour,,Middle,
+27516511,J. Graham Brown School,,12/5/2025 8:30 AM,,School Tour,,Middle,
+27516511,J. Graham Brown School,,12/17/2025 8:30 AM,,School Tour,,Middle,
+275396,Jefferson County Traditional Middle,,11/17/2025 6:00 PM,11/17/2025 7:30 PM,School Tour,,Middle,
+275470,Johnson Traditional Middle,,10/30/2025 9:00 AM,10/30/2025 10:00 AM,Open House,Call to confirm time,Middle,
+275470,Johnson Traditional Middle,,11/6/2025 9:00 AM,11/6/2025 10:00 AM,School Tour,,Middle,
+275470,Johnson Traditional Middle,,11/13/2025 9:00 AM,11/13/2025 10:00 AM,School Tour,,Middle,
+275470,Johnson Traditional Middle,,11/20/2025 9:00 AM,11/20/2025 10:00 AM,School Tour,,Middle,
+275470,Johnson Traditional Middle,,12/4/2025 9:00 AM,12/4/2025 10:00 AM,School Tour,,Middle,
+275162,Kammerer Middle,,10/30/2025 5:30 PM,10/30/2025 7:00 PM,Open House,,Middle,
+275163,Knight Middle,(502) 485-8287,,,School Tour,,Middle,
+275133,Lassiter Middle,(502) 485-8288,,,School Tour,,Middle,
+275340,Meyzeek Middle,(502) 485-8299,11/5/2025 5:30 PM,11/5/2025 7:30 PM,Open House,,Middle,
+275340,Meyzeek Middle,(502) 485-8299,,,School Tour,Tours are M-F from 9:00-10:30 AM,Middle,
+275041,Newburg Middle,,10/31/2025 9:00 AM,10/31/2025 10:00 AM,School Tour,,Middle,
+275041,Newburg Middle,,11/7/2025 9:00 AM,11/7/2025 10:00 AM,School Tour,,Middle,
+275041,Newburg Middle,,11/13/2025 5:30 PM,11/13/2025 7:00 PM,Open House,,Middle,
+275041,Newburg Middle,,11/14/2025 9:00 AM,11/14/2025 10:00 AM,School Tour,,Middle,
+275041,Newburg Middle,,11/21/2025 9:00 AM,11/21/2025 10:00 AM,School Tour,,Middle,
+275041,Newburg Middle,,12/5/2025 9:00 AM,12/5/2025 10:00 AM,School Tour,,Middle,
+275041,Newburg Middle,,12/12/2025 9:00 AM,12/12/2025 10:00 AM,School Tour,,Middle,
+275041,Newburg Middle,,12/19/2025 9:00 AM,12/19/2025 10:00 AM,School Tour,,Middle,
+275186,Newcomer Academy,(502) 398-3125,,,School Tour,Tours are 8:00 AM-2:00 PM,Middle,
+275435,Noe Middle,,11/6/2025 6:00 PM,,Open House,,Middle,
+275435,Noe Middle,,11/12/2025 9:30 AM,,School Tour,,Middle,
+275435,Noe Middle,,11/14/2025 9:30 AM,,School Tour,,Middle,
+275435,Noe Middle,,11/18/2025 9:30 AM,,School Tour,,Middle,
+275620,Olmsted Academy North,(502) 485-8331,,,School Tour,,Middle,
+275730,Olmsted Academy South,,10/28/2025 9:05 AM,10/28/2025 9:45 AM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/30E0C49A4A72AA7F94-58512953-olmsted)
+275730,Olmsted Academy South,,11/18/2025 9:05 AM,11/18/2025 9:45 AM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/30E0C49A4A72AA7F94-58512953-olmsted)
+275730,Olmsted Academy South,,12/3/2025 9:05 AM,12/3/2025 9:45 AM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/30E0C49A4A72AA7F94-58512953-olmsted)
+275730,Olmsted Academy South,,12/9/2025 9:05 AM,12/9/2025 9:45 AM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/30E0C49A4A72AA7F94-58512953-olmsted)
+2752011,Phoenix School of Discovery,(502) 212-4547,,,School Tour,,Middle,
+275219,Ramsey Middle,(502) 485-8391,11/4/2025 5:30 PM,11/4/2025 7:00 PM,School Tour,Or call to schedule alternate day,Middle,
+275144,Stuart Middle School,,11/10/2025 5:30 PM,11/10/2025 7:00 PM,School Tour,,Middle,
+275090,Thomas Jefferson Middle,(502) 485-8273,,,School Tour,,Middle,
+275710,Western Middle School for the Arts,,10/29/2025 7:00 PM,,Open House,,Middle,
+275710,Western Middle School for the Arts,,11/12/2025 9:00 AM,,School Tour,,Middle,
+275710,Western Middle School for the Arts,,11/17/2025 12:00 PM,,School Tour,,Middle,
+275710,Western Middle School for the Arts,,11/19/2025 9:00 AM,,School Tour,,Middle,
+275710,Western Middle School for the Arts,,11/24/2025 12:00 PM,,School Tour,,Middle,
+275710,Western Middle School for the Arts,,12/3/2025 9:00 AM,,School Tour,,Middle,
+275710,Western Middle School for the Arts,,12/8/2025 12:00 PM,,School Tour,,Middle,
+275710,Western Middle School for the Arts,,12/10/2025 9:00 AM,,School Tour,,Middle,
+275077,Westport Middle,,11/6/2025 5:30 PM,11/6/2025 7:00 PM,Open House,,Middle,
+275077,Westport Middle,,,,School Tour,Tours on select Tuesdays/Thursdays at 9:00 AM. See Westport Website for School Tour Sign Up,Middle,
+275049,Farnsley Middle,,11/4/2025 8:45 AM,11/4/2025 9:30 AM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/70A0448A9AF23A7FE3-farnsley2#/)
+275049,Farnsley Middle,,11/6/2025 8:45 AM,11/6/2025 9:30 AM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/70A0448A9AF23A7FE3-farnsley2#/)
+275049,Farnsley Middle,,11/11/2025 8:45 AM,11/11/2025 9:30 AM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/70A0448A9AF23A7FE3-farnsley2#/)
+275049,Farnsley Middle,,11/13/2025 8:45 AM,11/13/2025 9:30 AM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/70A0448A9AF23A7FE3-farnsley2#/)
+275049,Farnsley Middle,,11/18/2025 8:45 AM,11/18/2025 9:30 AM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/70A0448A9AF23A7FE3-farnsley2#/)
+275049,Farnsley Middle,,11/20/2025 8:45 AM,11/20/2025 9:30 AM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/70A0448A9AF23A7FE3-farnsley2#/)
+275049,Farnsley Middle,,11/25/2025 8:45 AM,11/25/2025 9:30 AM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/70A0448A9AF23A7FE3-farnsley2#/)
+2758001,Grace M. James Academy of Excellence,,10/22/2025 1:00 PM,10/22/2025 2:00 PM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+2758001,Grace M. James Academy of Excellence,,11/19/2025 1:00 PM,11/19/2025 2:00 PM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+2758001,Grace M. James Academy of Excellence,,12/3/2025 1:00 PM,12/3/2025 2:00 PM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+2758001,Grace M. James Academy of Excellence,,12/10/2025 1:00 PM,12/10/2025 2:00 PM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+2758001,Grace M. James Academy of Excellence,,12/17/2025 1:00 PM,12/17/2025 2:00 PM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+2758001,Grace M. James Academy of Excellence,,1/21/2026 1:00 PM,1/21/2026 2:00 PM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+2758001,Grace M. James Academy of Excellence,,2/18/2026 1:00 PM,2/18/2026 2:00 PM,School Tour,,Middle,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+275018,Atherton High,,10/30/2025 6:00 PM,,Open House,,High,
+275105,Ballard High,,11/6/2025 6:30 PM,,Open House,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+2751652,J. Graham Brown School,,11/7/2025 8:30 AM,,School Tour,,High,
+2751652,J. Graham Brown School,,11/11/2025 8:30 AM,,School Tour,,High,
+2751652,J. Graham Brown School,,11/18/2025 8:30 AM,,School Tour,,High,
+2751652,J. Graham Brown School,,12/5/2025 8:30 AM,,School Tour,,High,
+2751652,J. Graham Brown School,,12/17/2025 8:30 AM,,School Tour,,High,
+275045,Butler Traditional High,,11/11/2025 5:30 PM,,Open House,,High,
+275179,Central High Magnet Career Academy,,10/29/2025 8:30 AM,,School Tour,,High,
+275179,Central High Magnet Career Academy,,11/6/2025 6:00 PM,,Open House,,High,
+275179,Central High Magnet Career Academy,,11/12/2025 8:30 AM,,School Tour,,High,
+275179,Central High Magnet Career Academy,,11/19/2025 8:30 AM,,School Tour,,High,
+275179,Central High Magnet Career Academy,,12/3/2025 8:30 AM,,School Tour,,High,
+275179,Central High Magnet Career Academy,,12/10/2025 8:30 AM,,School Tour,,High,
+275100,Doss High,,11/3/2025 1:00 PM,11/3/2025 3:00 PM,Open House,,High,
+2752002,DuPont Manual High,,10/9/2025 1:00 PM,10/9/2025 3:00 PM,School Tour,,High,
+2752002,DuPont Manual High,,10/16/2025 1:00 PM,10/16/2025 3:00 PM,School Tour,,High,
+2752002,DuPont Manual High,,10/23/2025 1:00 PM,10/23/2025 3:00 PM,School Tour,,High,
+2752002,DuPont Manual High,,10/28/2025 6:00 PM,,Open House,,High,
+2752002,DuPont Manual High,,10/30/2025 1:00 PM,10/30/2025 3:00 PM,School Tour,,High,
+2752002,DuPont Manual High,,11/6/2025 1:00 PM,11/6/2025 3:00 PM,School Tour,,High,
+2752002,DuPont Manual High,,11/13/2025 1:00 PM,11/13/2025 3:00 PM,School Tour,,High,
+275007,Eastern High,,11/4/2025 6:00 PM,,Open House,,High,
+275012,Fern Creek High,,12/9/2025 6:00 PM,,Open House,,High,
+275057,Fairdale High,,11/11/2025 9:00 AM,11/11/2025 12:00 PM,School Tour,,High,[Register via this link](https://www.signupgenius.com/go/10C094BAAAE2DABFCCF8-58169344-fairdale#/)
+275057,Fairdale High,,11/13/2025 9:00 AM,11/13/2025 12:00 PM,School Tour,,High,[Register via this link](https://www.signupgenius.com/go/10C094BAAAE2DABFCCF8-58169344-fairdale#/)
+275335,Iroquois High,,11/13/2025 5:30 PM,,Open House,,High,
+2758002,Grace M. James Academy of Excellence,,11/4/2025 6:30 PM,,Open House,,High,
+275065,Jeffersontown High,(502) 485-8275,,,School Tour,,High,
+275047,Louisville Male High,,11/13/2025 6:00 PM,,Open House,,High,
+2751552,Marion C. Moore School,(502) 485-8304,,,School Tour,,High,
+2752012,Phoenix School of Discovery,(502) 212-4547,,,School Tour,,High,
+275075,Pleasure Ridge Park High,(502) 485-8311,,,School Tour,Tours are 9-11 AM and 1-3 PM,High,
+275073,Seneca High,,12/1/2025 6:30 PM,,Open House,,High,
+2755902,The Academy @ Shawnee,,11/3/2025 1:00 PM,11/3/2025 4:00 PM,Open House,,High,
+275031,Southern High,,10/30/2025 6:00 PM,10/30/2025 7:00 PM,Open House,,High,
+275033,Valley High,,11/3/2025 1:00 PM,11/3/2025 3:00 PM,Open House,,High,
+275033,Valley High,,11/4/2025 9:00 AM,11/4/2025 11:00 AM,Open House,,High,
+275051,Waggener High,,10/29/2025 6:00 PM,10/29/2025 7:30 PM,Open House,,High,
+275084,Western High,(502) 485-8344,11/5/2025 6:30 PM,11/5/2025 8:00 PM,Open House,,High,
+275105,Ballard High,,9/22/2025 4:00 PM,9/22/2025 4:30 PM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,10/16/2025 4:00 PM,10/16/2025 4:30 PM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,10/27/2025 4:00 PM,10/27/2025 4:30 PM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,11/4/2025 4:00 PM,11/4/2025 4:30 PM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,11/20/2025 4:00 PM,11/20/2025 4:30 PM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,12/4/2025 4:00 PM,12/4/2025 4:30 PM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,9/25/2025 9:00 AM,9/25/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,10/7/2025 9:00 AM,10/7/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,10/9/2025 9:00 AM,10/9/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,10/14/2025 9:00 AM,10/14/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,10/16/2025 9:00 AM,10/16/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,10/23/2025 9:00 AM,10/23/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,10/28/2025 9:00 AM,10/28/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,10/30/2025 9:00 AM,10/30/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,11/6/2025 9:00 AM,11/6/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,11/11/2025 9:00 AM,11/11/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,11/13/2025 9:00 AM,11/13/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,11/18/2025 9:00 AM,11/18/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+275105,Ballard High,,11/20/2025 9:00 AM,11/20/2025 11:00 AM,School Tour,,High,[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)
+2758002,Grace M. James Academy of Excellence,,10/22/2025 1:00 PM,10/22/2025 2:00 PM,School Tour,,High,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+2758002,Grace M. James Academy of Excellence,,11/19/2025 1:00 PM,11/19/2025 2:00 PM,School Tour,,High,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+2758002,Grace M. James Academy of Excellence,,12/3/2025 1:00 PM,12/3/2025 2:00 PM,School Tour,,High,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+2758002,Grace M. James Academy of Excellence,,12/10/2025 1:00 PM,12/10/2025 2:00 PM,School Tour,,High,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+2758002,Grace M. James Academy of Excellence,,12/17/2025 1:00 PM,12/17/2025 2:00 PM,School Tour,,High,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+2758002,Grace M. James Academy of Excellence,,1/21/2026 1:00 PM,1/21/2026 2:00 PM,School Tour,,High,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)
+2758002,Grace M. James Academy of Excellence,,2/18/2026 1:00 PM,2/18/2026 2:00 PM,School Tour,,High,[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)

--- a/data/open_house_dates.json
+++ b/data/open_house_dates.json
@@ -2,21 +2,25 @@
   "275175": {
     "phone": "(502) 485-6950",
     "notes": "Tours are 11:00 AM-2:00 PM",
+    "registration_link": null,
     "events": {}
   },
   "275185": {
     "phone": "(502) 485-8203",
     "notes": "Tours are 9:40-11:00 AM",
+    "registration_link": null,
     "events": {}
   },
   "275127": {
     "phone": "(502) 485-8204",
     "notes": "Tours are 8:00-9:00 AM",
+    "registration_link": null,
     "events": {}
   },
   "275044": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -41,6 +45,7 @@
   "275055": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -113,11 +118,13 @@
   "275149": {
     "phone": "(502) 485-8210",
     "notes": "Tours are 7:30-9:30 AM",
+    "registration_link": null,
     "events": {}
   },
   "275225": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -130,16 +137,19 @@
   "275091": {
     "phone": "(502) 485-8212",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275094": {
     "phone": "(502) 485-8213",
     "notes": "Tours are 11:00 AM-2:00 PM",
+    "registration_link": null,
     "events": {}
   },
   "275260": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -204,31 +214,37 @@
   "275038": {
     "phone": "(502) 485-8215",
     "notes": "Tours are 10:00 AM-3:00 PM and 4:45-5:15 PM",
+    "registration_link": null,
     "events": {}
   },
   "275243": {
     "phone": "(502) 485-8221",
     "notes": "Tours are 10:30 AM-2:00 PM",
+    "registration_link": null,
     "events": {}
   },
   "275004": {
     "phone": "(502)485-8222",
     "notes": "Tours are 8:00 AM - 1:00 PM",
+    "registration_link": null,
     "events": {}
   },
   "275005": {
     "phone": "(502) 485-8223",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275680": {
     "phone": "(502) 485-8225",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275102": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -252,7 +268,8 @@
   },
   "275046": {
     "phone": null,
-    "notes": "15 minutes",
+    "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -273,11 +290,13 @@
   "275323": {
     "phone": "(502) 485-8230",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275083": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -290,6 +309,7 @@
   "275660": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -338,36 +358,43 @@
   "275060": {
     "phone": "(502) 485-8234",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275092": {
     "phone": "(502) 485-8236",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275082": {
     "phone": "(502) 485-8238",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275156": {
     "phone": "(502) 485-8240",
-    "notes": "Tours are  9/9,10/10,11/6,12/5",
+    "notes": "Tours are  9/9, 10/10, 11/6, 12/5",
+    "registration_link": null,
     "events": {}
   },
   "275131": {
     "phone": "(502) 485-8244",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275010": {
     "phone": "(502) 485-8247",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275212": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -383,7 +410,8 @@
   },
   "275011": {
     "phone": "(502) 485-8250",
-    "notes": "Or call to schedule",
+    "notes": "Call to schedule alternate day",
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -396,26 +424,31 @@
   "275250": {
     "phone": "(502) 485-8252",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275270": {
     "phone": "(502) 485-8253",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275290": {
     "phone": "(502) 485-8255",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275061": {
     "phone": "(502) 485-8258",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275013": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -440,21 +473,25 @@
   "275014": {
     "phone": "(502) 485-8260",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275115": {
     "phone": "(502) 485-8261",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275121": {
     "phone": "(502) 485-8262",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275048": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -479,11 +516,13 @@
   "275300": {
     "phone": "(502) 485-8264",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275095": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -496,11 +535,13 @@
   "275076": {
     "phone": "(502) 485-8268",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "2751651": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -529,36 +570,43 @@
   "275325": {
     "phone": "(502) 485-8271",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275166": {
     "phone": "(502) 485-8274",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275106": {
     "phone": "(502) 485-8278",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275720": {
     "phone": "(502) 485-8280",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275059": {
     "phone": "(502) 485-8283",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275079": {
     "phone": "(502) 485-8284",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275432": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -571,21 +619,25 @@
   "275134": {
     "phone": "(502) 485-8286",
     "notes": "Tours are 8/15-12/20",
+    "registration_link": null,
     "events": {}
   },
   "275145": {
     "phone": "(502) 485-8289",
     "notes": "Tours are 10/27-12/12",
+    "registration_link": null,
     "events": {}
   },
   "275126": {
     "phone": "(502) 485-8290",
     "notes": "Tours are October-April",
+    "registration_link": null,
     "events": {}
   },
   "275520": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -602,16 +654,19 @@
   "275146": {
     "phone": "(502) 485-8293",
     "notes": "Tours are 10/28, 10/29, 117, 11/14, and 12/5",
+    "registration_link": null,
     "events": {}
   },
   "275107": {
     "phone": "(502) 485-8295",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275480": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -624,16 +679,19 @@
   "275440": {
     "phone": "(502) 485-8297",
     "notes": "Tours are 10:30-11:30 AM",
+    "registration_link": null,
     "events": {}
   },
   "275022": {
     "phone": "(502) 485-8298",
     "notes": "Tours are 10:30 AM-3:30 PM",
+    "registration_link": null,
     "events": {}
   },
   "275024": {
     "phone": "(502) 485-8300",
-    "notes": "Or Call to Schedule",
+    "notes": "Or call to schedule alternate day",
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -646,16 +704,19 @@
   "275147": {
     "phone": "(502) 485-8301",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275099": {
     "phone": "(502) 485-8303",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275371": {
     "phone": "(502) 485-8367",
-    "notes": "Or Call to Schedule",
+    "notes": "Or call to schedule alternate day",
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -680,6 +741,7 @@
   "275096": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -696,71 +758,85 @@
   "275027": {
     "phone": "(502) 485-8309",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275182": {
     "phone": "(502) 485-8348",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275500": {
     "phone": "(502) 485-8313",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275128": {
     "phone": "(502) 485-8315",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275081": {
     "phone": "(502) 485-8317",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275560": {
     "phone": "(502) 485-8320",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275086": {
     "phone": "(502) 485-8322",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275063": {
     "phone": "(502) 485-8217",
     "notes": "Tours are 10/27-12/12",
+    "registration_link": null,
     "events": {}
   },
   "275580": {
     "phone": "(502) 485-8324",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275097": {
     "phone": "(502) 485-8325",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275610": {
     "phone": "(502) 485-8327",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275103": {
     "phone": "(502) 485-8328",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275087": {
     "phone": "(502) 485-8329",
     "notes": "Tours are 10/27-12/12",
+    "registration_link": null,
     "events": {}
   },
   "275064": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -781,11 +857,13 @@
   "275071": {
     "phone": "(502) 485-8333",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275211": {
     "phone": null,
-    "notes": "Register Via this Link",
+    "notes": null,
+    "registration_link": "[Register via this Link](https://www.signupgenius.com/go/10C0C48A8AE2FA6F5C43-50739498-stopher#/)",
     "events": {
       "School Tour": [
         {
@@ -818,11 +896,13 @@
   "275104": {
     "phone": "(502) 485-8337",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275016": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -850,7 +930,8 @@
   },
   "275072": {
     "phone": "(502) 485-8342",
-    "notes": "Or Call to Schedule",
+    "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -863,11 +944,13 @@
   "275116": {
     "phone": "(502) 485-8343",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275109": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -896,6 +979,7 @@
   "275067": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -916,26 +1000,31 @@
   "275066": {
     "phone": "(502) 485-8351",
     "notes": "Tours are 8:00 AM-1:00 PM",
+    "registration_link": null,
     "events": {}
   },
   "275117": {
     "phone": "(502) 485-8353",
     "notes": "Tours are 10/27-12/12",
+    "registration_link": null,
     "events": {}
   },
   "275374": {
     "phone": "(502) 485-8246",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275078": {
     "phone": "(502) 485-8336",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275040": {
     "phone": "(502) 485-8207",
-    "notes": "Submit form to sign up",
+    "notes": null,
+    "registration_link": "[Register via this link](https://docs.google.com/forms/d/e/1FAIpQLSfsIRIo159SIiPXIZKk2FKIBUCwXfCInLE3IbM5DAvbJhe0tA/viewform)",
     "events": {
       "Open House": [
         {
@@ -965,7 +1054,8 @@
   },
   "275167": {
     "phone": "(502) 485-8224",
-    "notes": "Or Call to Schedule a Visit",
+    "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -978,11 +1068,13 @@
   "275164": {
     "phone": "(502) 485-8233",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275119": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -995,6 +1087,7 @@
   "2751911": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -1023,6 +1116,7 @@
   "275255": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1088,7 +1182,8 @@
   },
   "275049": {
     "phone": null,
-    "notes": "Submit form to sign up",
+    "notes": null,
+    "registration_link": "[Register via this link](https://www.signupgenius.com/go/70A0448A9AF23A7FE3-farnsley2#/)",
     "events": {
       "Open House": [
         {
@@ -1130,7 +1225,8 @@
   },
   "2758001": {
     "phone": null,
-    "notes": "Submit form to sign up",
+    "notes": null,
+    "registration_link": "[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)",
     "events": {
       "Open House": [
         {
@@ -1173,6 +1269,7 @@
   "275320": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1199,11 +1296,13 @@
   "275406": {
     "phone": "(502) 485-8187",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "27516511": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -1232,6 +1331,7 @@
   "275396": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -1244,6 +1344,7 @@
   "275470": {
     "phone": null,
     "notes": "Call to confirm time",
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1274,6 +1375,7 @@
   "275162": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1286,16 +1388,19 @@
   "275163": {
     "phone": "(502) 485-8287",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275133": {
     "phone": "(502) 485-8288",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275340": {
     "phone": "(502) 485-8299",
     "notes": "Tours are M-F from 9:00-10:30 AM",
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1308,6 +1413,7 @@
   "275041": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1350,11 +1456,13 @@
   "275186": {
     "phone": "(502) 398-3125",
     "notes": "Tours are 8:00 AM-2:00 PM",
+    "registration_link": null,
     "events": {}
   },
   "275435": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1381,11 +1489,13 @@
   "275620": {
     "phone": "(502) 485-8331",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275730": {
     "phone": null,
-    "notes": "Submit form to sign up",
+    "notes": null,
+    "registration_link": "[Register via this link](https://www.signupgenius.com/go/30E0C49A4A72AA7F94-58512953-olmsted)",
     "events": {
       "School Tour": [
         {
@@ -1410,11 +1520,13 @@
   "2752011": {
     "phone": "(502) 212-4547",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275219": {
     "phone": "(502) 485-8391",
-    "notes": "Or Call to Schedule a Visit",
+    "notes": "Or call to schedule alternate day",
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -1427,6 +1539,7 @@
   "275144": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -1439,11 +1552,13 @@
   "275090": {
     "phone": "(502) 485-8273",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275710": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1486,6 +1601,7 @@
   "275077": {
     "phone": null,
     "notes": "Tours on select Tuesdays/Thursdays at 9:00 AM. See Westport Website for School Tour Sign Up",
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1498,6 +1614,7 @@
   "275018": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1509,7 +1626,8 @@
   },
   "275105": {
     "phone": null,
-    "notes": "Shadow Visit. More information and sign up",
+    "notes": null,
+    "registration_link": "[Register via this link](https://www.canva.com/design/DAFtBzkcmog/irRehTkoWOzNstAWePMElw/view?utm_content=DAFtBzkcmog&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h546e2a921c)",
     "events": {
       "Open House": [
         {
@@ -1600,6 +1718,7 @@
   "2751652": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "School Tour": [
         {
@@ -1628,6 +1747,7 @@
   "275045": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1640,6 +1760,7 @@
   "275179": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1674,6 +1795,7 @@
   "275100": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1686,6 +1808,7 @@
   "2752002": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1724,6 +1847,7 @@
   "275007": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1736,6 +1860,7 @@
   "275012": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1747,7 +1872,8 @@
   },
   "275057": {
     "phone": null,
-    "notes": "Submit form to sign up",
+    "notes": null,
+    "registration_link": "[Register via this link](https://www.signupgenius.com/go/10C094BAAAE2DABFCCF8-58169344-fairdale#/)",
     "events": {
       "School Tour": [
         {
@@ -1764,6 +1890,7 @@
   "275335": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1775,7 +1902,8 @@
   },
   "2758002": {
     "phone": null,
-    "notes": "Submit form to sign up",
+    "notes": null,
+    "registration_link": "[Register via this link](https://www.signupgenius.com/go/409044CAAAD2DABFC1-57215177-2526#/)",
     "events": {
       "Open House": [
         {
@@ -1818,11 +1946,13 @@
   "275065": {
     "phone": "(502) 485-8275",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275047": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1835,21 +1965,25 @@
   "2751552": {
     "phone": "(502) 485-8304",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "2752012": {
     "phone": "(502) 212-4547",
     "notes": null,
+    "registration_link": null,
     "events": {}
   },
   "275075": {
     "phone": "(502) 485-8311",
     "notes": "Tours are 9-11 AM and 1-3 PM",
+    "registration_link": null,
     "events": {}
   },
   "275073": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1862,6 +1996,7 @@
   "2755902": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1874,6 +2009,7 @@
   "275031": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1886,6 +2022,7 @@
   "275033": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1902,6 +2039,7 @@
   "275051": {
     "phone": null,
     "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {
@@ -1913,7 +2051,8 @@
   },
   "275084": {
     "phone": "(502) 485-8344",
-    "notes": "Or Call to Schedule a Visit",
+    "notes": null,
+    "registration_link": null,
     "events": {
       "Open House": [
         {


### PR DESCRIPTION
Integrates seasonal school tour and open house schedules into the application. This commit includes the back-end data and logic required for the feature.

- A new, decoupled data source (`open_house_dates.json`) is introduced to store temporary event data. This is generated from a structured CSV to make annual updates simple.
- A utility script (`generate_open_house_json.py`) is added to process the source CSV and create the final JSON.
- The API is updated to load this new JSON file at startup and merge the complete tour data object into the school details payload under the 'open_house_data' key for consumption by the front-end.